### PR TITLE
Fix: version printing now relies on the packaged pyproject.toml

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -23,7 +23,7 @@ def capture_solution_request(solution_path: str):
 
 
 async def cli(args, script_root: Path):
-    starklings_directory = StarklingsDirectory(script_root)
+    starklings_directory = StarklingsDirectory()
     version_manager = VersionManager(starklings_directory)
 
     if args.version:

--- a/src/utils/starklings_directory_test.py
+++ b/src/utils/starklings_directory_test.py
@@ -1,29 +1,8 @@
-from pathlib import Path
-
-import pytest
-
 from src.utils.starklings_directory import StarklingsDirectory, VersionManager
 
 
-@pytest.fixture(name="script_root")
-def script_root_fixture(tmpdir: str) -> Path:
-    return Path(tmpdir)
-
-
-def test_starklings_binary_dir_path(script_root: Path):
-    starklings_directory = StarklingsDirectory(script_root)
-
-    assert starklings_directory.binary_dir_path == script_root
-
-
-def test_directory_root_path(script_root: Path):
-    starklings_directory = StarklingsDirectory(script_root)
-
-    assert starklings_directory.root_dir_path == script_root / ".." / ".."
-
-
 def test_version_manager():
-    starklings_directory = StarklingsDirectory(Path(__file__).parent)
+    starklings_directory = StarklingsDirectory()
     version_manager = VersionManager(starklings_directory)
 
     assert version_manager.starklings_version > VersionManager.parse("0.0.0")

--- a/starklings.py
+++ b/starklings.py
@@ -35,9 +35,8 @@ root_parser.add_argument(
 
 def is_valid_file(parser, arg):
     if not os.path.exists(arg):
-        parser.error(f"The file {arg} does not exist!")
-    else:
-        return Path(arg)
+        return parser.error(f"The file {arg} does not exist!")
+    return Path(arg)
 
 
 root_parser.add_argument(


### PR DESCRIPTION
Closes #125 