### PR TITLE
chore: simplify bitwise exercise op assertion

### DIFF
--- a/.patches/builtins/bitwise.cairo.patch
+++ b/.patches/builtins/bitwise.cairo.patch
@@ -13,11 +13,10 @@
 -    # FILL ME
 +    let (pow2n) = pow(2, n)
 +    let (res) = bitwise_xor(value, pow2n)
-@@ -55 +59,3 @@
+@@ -55 +59,2 @@
 -    # Assert op is correct
-+    let tmp_op_invalid = (op - 'get') * (op - 'set') * (op - 'toggle')
-+    let (is_op_invalid) = is_not_zero(tmp_op_invalid)
-+    assert 0 = is_op_invalid
++    # Product can only be zero if op in ['get', 'set', 'toggle']
++    assert 0 = (op - 'get') * (op - 'set') * (op - 'toggle')
 @@ -58 +64,2 @@
 -        # Assert n is within bounds
 +        assert_nn(n)


### PR DESCRIPTION
Hi there, first of all thanks for creating this wonderful exercise! 🍻 After finishing, I looked into the solution in the `.patch` file and was thinking if the `op` assertion can be simplified into one line instead of three? It's a bit easier to digest this way I believe 🙂 Please let me know what you think, thanks!